### PR TITLE
update urllib3 to resolve CVE-2019-11324

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ chardet==3.0.4            # via requests
 idna==2.6                 # via requests
 nose==1.3.7
 requests==2.21.0
-urllib3==1.24.1           # via requests
+urllib3==1.24.2           # via requests


### PR DESCRIPTION
# What Are We Doing Here

Updating urllib3 to a newer version that patches the latest CVE.

## How to Verify

1. All tests still pass. No functionality changes.

